### PR TITLE
INF-548/mz/experimental

### DIFF
--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -212,7 +212,7 @@ class ShellTask(PythonInstanceTask[T]):
 
         if "env" in kwargs:
             kwargs["export_env"] = self.make_export_string_from_env_dict(kwargs["env"])
-        breakpoint()
+
         gen_script = self._interpolizer.interpolate(self._script, inputs=kwargs, outputs=outputs)
         if self._debug:
             print("\n==============================================\n")

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -219,6 +219,8 @@ class ShellTask(PythonInstanceTask[T]):
             self._script = self._script.lstrip().rstrip().replace("\n", "&&")
 
         if "env" in kwargs and isinstance(kwargs["env"], dict):
+            # This supports the portable_shell_task by adding an additional key:value pair to kwargs/input
+            # This will cause collisions if a user tries to use `env` AND `export_env` in their inputs
             kwargs["export_env"] = self.make_export_string_from_env_dict(kwargs["env"])
 
         gen_script = self._interpolizer.interpolate(self._script, inputs=kwargs, outputs=outputs)

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -255,7 +255,9 @@ class ShellTask(PythonInstanceTask[T]):
     def post_execute(self, user_params: ExecutionParameters, rval: typing.Any) -> typing.Any:
         return self._config_task_instance.post_execute(user_params, rval)
 
-
+# The portable_shell_task is an instance of ShellTask which wraps a 'pure' shell script
+# This utility function allows for the specification of env variables, arguments, and the actual script within the
+# workflow definition rather than at `ShellTask` instantiation
 portable_shell_task = ShellTask(
     name="portable_shell_task_instance",
     debug=True,

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -184,7 +184,15 @@ class ShellTask(PythonInstanceTask[T]):
     def script_file(self) -> typing.Optional[os.PathLike]:
         return self._script_file
 
-    def make_export_string_from_env_dict(self, d):
+    def make_export_string_from_env_dict(self, d) -> str:
+        """
+        Utility function to convert a dictionary of desired environment variable key: value pairs into a string of
+        `
+        export k1=v1
+        export k2=v2
+        ...
+        `
+        """
         items = []
         for k, v in d.items():
             items.append(f"export {k}={v}")
@@ -210,7 +218,7 @@ class ShellTask(PythonInstanceTask[T]):
         if os.name == "nt":
             self._script = self._script.lstrip().rstrip().replace("\n", "&&")
 
-        if "env" in kwargs:
+        if "env" in kwargs and isinstance(kwargs["env"], dict):
             kwargs["export_env"] = self.make_export_string_from_env_dict(kwargs["env"])
 
         gen_script = self._interpolizer.interpolate(self._script, inputs=kwargs, outputs=outputs)

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -255,8 +255,8 @@ portable_shell_task = ShellTask(
     output_locs=[
         OutputLocation(
             var="k",
-            var_type=FlyteFile,
-            location="{ctx.working_directory}/test_output.txt",
+            var_type=FlyteDirectory,
+            location="{ctx.working_directory}",
         )
     ],
     script="""

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -212,7 +212,7 @@ class ShellTask(PythonInstanceTask[T]):
 
         if "env" in kwargs:
             kwargs["export_env"] = self.make_export_string_from_env_dict(kwargs["env"])
-
+        breakpoint()
         gen_script = self._interpolizer.interpolate(self._script, inputs=kwargs, outputs=outputs)
         if self._debug:
             print("\n==============================================\n")
@@ -251,7 +251,7 @@ class ShellTask(PythonInstanceTask[T]):
 portable_shell_task = ShellTask(
     name="portable_shell_task_instance",
     debug=True,
-    inputs=kwtypes(env=typing.Dict[str, str], script_args=str, script_file=str),
+    inputs=flytekit.kwtypes(env=typing.Dict[str, str], script_args=str, script_file=str),
     output_locs=[
         OutputLocation(
             var="k",
@@ -260,14 +260,14 @@ portable_shell_task = ShellTask(
         )
     ],
     script="""
-    #!/bin/bash
+#!/bin/bash
 
-    set -uexo pipefail
+set -uexo pipefail
 
-    cd {ctx.working_directory}
+cd {ctx.working_directory}
 
-    {inputs.export_env}
+{inputs.export_env}
 
-    bash {inputs.script_file} {inputs.script_args}
+bash {inputs.script_file} {inputs.script_args}
     """
 )

--- a/tests/flytekit/unit/extras/tasks/testdata/script_args_env.sh
+++ b/tests/flytekit/unit/extras/tasks/testdata/script_args_env.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -exo pipefail
+
+echo "A: $A"
+echo "B: $B"
+
+if [ ! -z $1 ]; then
+    echo $1
+else
+    echo "Unset first positional argument"
+fi
+
+if [ ! -z $2 ]; then
+    echo $2
+else
+    echo "Unset second positional argument"
+fi
+
+SOME_VAR="This var is set"
+
+echo "Reading SOME_VAR: ${SOME_VAR}"


### PR DESCRIPTION
A better implementation of porting an existing script, need to test this with the brewer script but it supports the simple test case which utilizes all the same features. `script_args` could technically be a `List[str]` which would allow further control over the individual items but right now, they are just being passed as `$@`.

The one annoying limitation with this template is that it does not allow user to specify outputs as the fixed output is the current context working directory. So if your script takes an input directory as a work directory, this template will run and execute but there it will not output that working directory for downstream use. Example, your script takes in a work dir, `cd` into the work dir, and generates all outputs there. Those outputs will be there, but the work dir cannot be exported as a `FlyteDirectory` since that is done when at shell task instantiation. 

There's probably a work around but I haven't thought too much into it yet. It's further complicated in the fact that the input work dir would be part of the `script args` string.

Important to note that the location of the script you are trying to port must be the same as what will eventually be in the container. To harden this requirement, it's advised to serialize / package your workflows and tasks within the container that it will eventually be run in.

To use:
```python
from flytekit.extras.tasks.shell  import portable_shell_task

@workflow
def run_dummies_alt() -> None:

    x_str, y_str = t1(a=20)
    o = portable_shell_task(
        script_args="arg_1 arg_2",
        env={
            "A": y_str,
            "B": x_str,
        },
        script_file="/path/to/your/script"
    )
    test_read_shell_task(x=o)
```

