### PR TITLE
minor fix, have function return the instance rather than create. It s…

### DIFF
--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -257,10 +257,12 @@ class ShellTask(PythonInstanceTask[T]):
     def post_execute(self, user_params: ExecutionParameters, rval: typing.Any) -> typing.Any:
         return self._config_task_instance.post_execute(user_params, rval)
 
+
 # The portable_shell_task is an instance of ShellTask which wraps a 'pure' shell script
 # This utility function allows for the specification of env variables, arguments, and the actual script within the
 # workflow definition rather than at `ShellTask` instantiation
-portable_shell_task = ShellTask(
+def get_portable_shell_task() -> ShellTask:
+    return ShellTask(
     name="portable_shell_task_instance",
     debug=True,
     inputs=flytekit.kwtypes(env=typing.Dict[str, str], script_args=str, script_file=str),


### PR DESCRIPTION
Seems to be a problem during serialization/packaging. Because the `portable_shell_task` is an instance of `ShellTask` and lives in `shell`, it seems to be getting packaged as a task when I package the workflow. The fix is to just have a function return the instance instead for use. 